### PR TITLE
Change docker compose to use backend dev image

### DIFF
--- a/{{cookiecutter.project_slug}}/docker-compose.yaml
+++ b/{{cookiecutter.project_slug}}/docker-compose.yaml
@@ -15,10 +15,12 @@ services:
     container_name: backend
     build:
       context: ./backend
+      target: dev
     volumes:
       - ./backend:/app
       - static:/app/static
       - media:/app/media
+      - ~/.ssh:/root/.ssh-localhost:ro
     depends_on:
       - postgres
     environment:


### PR DESCRIPTION
docker-compose now uses the dev image by default and has the user default .ssh directory mapped internally for git to work properly.