### PR TITLE
Fix #91 Add __debug__ to nginx paths configuration

### DIFF
--- a/{{cookiecutter.project_slug}}/nginx/paths.conf
+++ b/{{cookiecutter.project_slug}}/nginx/paths.conf
@@ -19,6 +19,16 @@ location /api/ {
     proxy_set_header X-Real-IP           $remote_addr;
     proxy_set_header X-Scheme            https;
 }
+
+location /__debug__/ {
+    proxy_pass http://django$request_uri;
+    proxy_redirect http:// https://;
+    proxy_set_header Host                $http_host;
+    proxy_set_header X-Forwarded-For     $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto   https;
+    proxy_set_header X-Real-IP           $remote_addr;
+    proxy_set_header X-Scheme            https;
+}
 {% if cookiecutter.use_media == "Yes" %}
 location /media/ {
     proxy_pass http://django$request_uri;


### PR DESCRIPTION
Django debug toolbar not work properly without a location path set in nginx paths configurations