### PR TITLE
Fix traefik https redirect

### DIFF
--- a/{{cookiecutter.project_dirname}}/terraform/networking/modules/kubernetes/traefik/main.tf
+++ b/{{cookiecutter.project_dirname}}/terraform/networking/modules/kubernetes/traefik/main.tf
@@ -33,7 +33,7 @@ resource "helm_release" "traefik" {
         var.ssl_enabled == "true" ? {
           additionalArguments = concat(
             [
-              "--entrypoints.web.http.redirections.entryPoint.to=websecure",
+              "--entrypoints.web.http.redirections.entryPoint.to=:443",
               "--entrypoints.websecure.http.tls=true",
             ],
             var.letsencrypt_certificate_email != "" ? [

--- a/{{cookiecutter.project_dirname}}/terraform/networking/modules/kubernetes/traefik/values.yaml
+++ b/{{cookiecutter.project_dirname}}/terraform/networking/modules/kubernetes/traefik/values.yaml
@@ -1,6 +1,6 @@
 logs:
   general:
-    level: "DEBUG"
+    level: "ERROR"
 
 providers:
   kubernetesIngress:


### PR DESCRIPTION
Redirect to `websecure` causes an undesired effect that returns in the first instance the redirect on port: 8443

https://github.com/traefik/traefik/issues/7038#issuecomment-657515786