### PR TITLE
Decrease traefik logs level

### DIFF
--- a/{{cookiecutter.project_dirname}}/terraform/networking/modules/kubernetes/traefik/values.yaml
+++ b/{{cookiecutter.project_dirname}}/terraform/networking/modules/kubernetes/traefik/values.yaml
@@ -1,6 +1,6 @@
 logs:
   general:
-    level: "DEBUG"
+    level: "ERROR"
 
 providers:
   kubernetesIngress:


### PR DESCRIPTION
I would leave the traefik log level at the default value `ERROR`, but leave these configurations to have the possibility to set it to `DEBUG` if needed.

https://doc.traefik.io/traefik/master/observability/logs/#level

Because the DEBUG level is very verbose and could accumulate unnecessarily logs in the `log-storage` volume storage.
